### PR TITLE
1834226 - Update forked repositories with python 3.9 deprecation warnings

### DIFF
--- a/nydus/db/base.py
+++ b/nydus/db/base.py
@@ -110,7 +110,7 @@ class BaseCluster(object):
         """
         connections = self.__connections_for('get_conn', args=args, kwargs=kwargs)
 
-        if len(connections) is 1:
+        if len(connections) == 1:
             return connections[0]
         else:
             return connections


### PR DESCRIPTION
https://dev.azure.com/Paycor/Paycor%20Agile/_workitems/edit/1834226

We have 4 under-maintained forked repos that will have a new deprecation warning in python 3.8+ related to the 'is' object comparison operator and this is one of the 4. See https://adamj.eu/tech/2020/01/21/why-does-python-3-8-syntaxwarning-for-is-literal/.

Basically, replace the 'is' keyword with '==' for each of the deprecated cases.

**Test:**
Download the file and verify that there are no SyntaxWarning's https://app.circleci.com/pipelines/github/7Geese/7Geese/18452/workflows/0dd2d7a5-84d7-41e0-a0ab-e3e8a0e1184a/jobs/286702